### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,23 +1,28 @@
 ---
 driver:
   name: vagrant
-  username: root
-  password: vagrant
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 12
+  product_name: chef
+  product_version: 13
 
 verifier:
   name: inspec
 
 platforms:
-  - name: bento/centos-7.2
+  - name: centos-6
+  - name: centos-7
+  - name: ubuntu-16.04
+  - name: amazonlinux-2
+    driver:
+      box: gbailey/amzn2
+      provision: True
+      vagrantfiles:
+        - al2_workaround.rb
 
 suites:
   - name: default
     run_list:
-      - recipe[yum-epel]
       - recipe[atop]
     attributes:
       atop:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # atop Cookbook
 
+[![Cookbook](http://img.shields.io/cookbook/v/atop.svg)](https://supermarket.chef.io/cookbooks/atop)
+
 This cookbook installs `atop`, starts it as a service to log data every configured interval, and configures logrotate on its log output.
 
 ## Requirements
 
 ### Platforms
 
-- CentOS
+- Amazon Linux 1 and 2
+- CentOS 6.x and 7.x
 - Debian
 
 ### Chef

--- a/al2_workaround.rb
+++ b/al2_workaround.rb
@@ -1,0 +1,7 @@
+# Workaround to fix OS detection on Amazon Linux 2
+# Related to: https://github.com/inspec/train/pull/380
+Vagrant.configure('2') do |config|
+  config.vm.provision 'shell', inline: <<-SHELL
+        sudo echo "Amazon Linux 2" > /etc/system-release
+    SHELL
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,12 +1,19 @@
 name             'atop'
 maintainer       'Keyan Pishdadian'
 maintainer_email 'kpishdadian@gmail.com'
-license          'All rights reserved'
+license          'Apache-2.0'
 description      'Installs/Configures atop'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/keyan/atop/'
 issues_url       'https://github.com/keyan/atop/issues'
-version          '1.0.3'
+version          '1.0.4'
 
 depends 'yum-epel'
 depends 'logrotate'
+
+supports 'amazon'
+supports 'centos'
+supports 'redhat'
+supports 'ubuntu'
+
+chef_version '>= 13'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,19 +5,24 @@
 # Copyright 2017, Keyan Pishdadian
 #
 
+case node['platform_family']
+when 'rhel', 'amazon'
+  include_recipe 'yum-epel'
+
+  conf_file_location = '/etc/sysconfig/atop'
+  template_source = 'atop-rhel.erb'
+
+when 'debian'
+  conf_file_location = '/etc/default/atop'
+  template_source = 'atop-debian.erb'
+
+else
+  Chef::Application.fatal!('Unsupported operating system', 1)
+end
+
 package 'atop' do
   action node['atop']['action']
   version node['atop']['version']
-end
-
-if platform_family?('rhel')
-  conf_file_location = '/etc/sysconfig/atop'
-  template_source = 'atop-rhel.erb'
-elsif platform_family?('debian')
-  conf_file_location = '/etc/default/atop'
-  template_source = 'atop-debian.erb'
-else
-  Chef::Application.fatal!('Unsupported operating system', 1)
 end
 
 template conf_file_location do
@@ -28,7 +33,7 @@ template conf_file_location do
     logpath: node['atop']['logpath'],
     interval: node['atop']['interval']
   )
-  notifies :restart, "service[atop]", :delayed
+  notifies :restart, 'service[atop]', :delayed
 end
 
 service 'atop' do

--- a/test/integration/default/inspec/default.rb
+++ b/test/integration/default/inspec/default.rb
@@ -3,14 +3,14 @@
 if os[:family] == 'redhat'
   describe file('/etc/sysconfig/atop') do
     it { should be_file }
-    its('content') { should match "LOGPATH" }
-    its('content') { should match "INTERVAL" }
+    its('content') { should match 'LOGPATH' }
+    its('content') { should match 'INTERVAL' }
   end
 elsif os[:family] == 'debian'
   describe file('/etc/default/atop') do
     it { should be_file }
-    its('content') { should match "LOGPATH" }
-    its('content') { should match "INTERVAL" }
+    its('content') { should match 'LOGPATH' }
+    its('content') { should match 'INTERVAL' }
   end
 end
 


### PR DESCRIPTION
I've added Amazon Linux 2 to the test-kitchen configurations to ensure this cookbook works on that platform. Since it's mostly based off of RHEL, it didn't need any other configuration changes.

I believe this also incorporates the ideas from #1 as well.